### PR TITLE
Integrate sqlite database support for aj-report

### DIFF
--- a/report-core/pom.xml
+++ b/report-core/pom.xml
@@ -131,6 +131,11 @@
             <version>${mysql.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
             <version>${druid.version}</version>

--- a/report-core/src/main/java/com/anjiplus/template/gaea/business/modules/datasource/service/impl/DataSourceServiceImpl.java
+++ b/report-core/src/main/java/com/anjiplus/template/gaea/business/modules/datasource/service/impl/DataSourceServiceImpl.java
@@ -104,6 +104,7 @@ public class DataSourceServiceImpl implements DataSourceService {
             case JdbcConstants.DAMENG:
             case JdbcConstants.OPENGAUSS:
             case JdbcConstants.KINGBASE:
+            case JdbcConstants.SQLITE:
                 testRelationalDb(dto);
                 break;
             case JdbcConstants.HTTP:
@@ -132,6 +133,7 @@ public class DataSourceServiceImpl implements DataSourceService {
             case JdbcConstants.DAMENG:
             case JdbcConstants.OPENGAUSS:
             case JdbcConstants.KINGBASE:
+            case JdbcConstants.SQLITE:
                 return executeRelationalDb(dto);
             case JdbcConstants.HTTP:
                 return executeHttp(dto);
@@ -155,6 +157,8 @@ public class DataSourceServiceImpl implements DataSourceService {
                 return 0;
             case JdbcConstants.MYSQL:
                 return mysqlTotal(sourceDto, dto);
+            case JdbcConstants.SQLITE:
+                return sqliteTotal(sourceDto, dto);
             default:
                 throw BusinessExceptionBuilder.build(ResponseCode.DATA_SOURCE_TYPE_DOES_NOT_MATCH_TEMPORARILY);
         }
@@ -177,6 +181,21 @@ public class DataSourceServiceImpl implements DataSourceService {
         int pageNumber = Integer.parseInt(dto.getContextData().getOrDefault("pageNumber", "1").toString());
         int pageSize = Integer.parseInt(dto.getContextData().getOrDefault("pageSize", "10").toString());
         String sqlLimit = " limit " + (pageNumber - 1) * pageSize + "," + pageSize;
+        sourceDto.setDynSentence(dynSentence.concat(sqlLimit));
+        log.info("当前total：{}, 添加分页参数,sql语句：{}", JSONObject.toJSONString(result), sourceDto.getDynSentence());
+        return result.get(0).getLongValue("count");
+    }
+
+    public long sqliteTotal(DataSourceDto sourceDto, DataSetDto dto){
+        String dynSentence = sourceDto.getDynSentence();
+        String sql = "select count(1) as count from (" + dynSentence + ") as gaeaExecute";
+        sourceDto.setDynSentence(sql);
+        List<JSONObject> result = execute(sourceDto);
+
+        int pageNumber = Integer.parseInt(dto.getContextData().getOrDefault("pageNumber", "1").toString());
+        int pageSize = Integer.parseInt(dto.getContextData().getOrDefault("pageSize", "10").toString());
+        int offset = (pageNumber - 1) * pageSize;
+        String sqlLimit = " limit " + pageSize + " offset " + offset;
         sourceDto.setDynSentence(dynSentence.concat(sqlLimit));
         log.info("当前total：{}, 添加分页参数,sql语句：{}", JSONObject.toJSONString(result), sourceDto.getDynSentence());
         return result.get(0).getLongValue("count");

--- a/report-core/src/main/resources/db/migration/V1.7.2__add_sqlite_source_type.sql
+++ b/report-core/src/main/resources/db/migration/V1.7.2__add_sqlite_source_type.sql
@@ -1,0 +1,12 @@
+-- Add SQLite source type into dictionary
+DELETE FROM gaea_dict_item WHERE dict_code = 'SOURCE_TYPE' AND item_value = 'sqlite';
+
+INSERT INTO gaea_dict_item
+    (dict_code, item_name, item_value, item_extend, enabled, locale, remark, sort, create_by, create_time, update_by, update_time, version)
+VALUES
+    ('SOURCE_TYPE', 'sqlite', 'sqlite',
+     '[{"label":"driverName","value":"org.sqlite.JDBC","labelValue":"驱动类"},
+       {"label":"jdbcUrl","value":"jdbc:sqlite:/app/data/sqlite/ajreport.db","labelValue":"连接串"},
+       {"label":"username","value":"","labelValue":"用户名"},
+       {"label":"password","value":"","labelValue":"密码"}]',
+     1, 'zh', NULL, 35, 'admin', NOW(), 'admin', NOW(), 1);


### PR DESCRIPTION
Add SQLite database support to expand data source options for AJ-Report users.

This PR integrates SQLite by adding the JDBC driver, extending the backend `DataSourceServiceImpl` to handle SQLite connections and pagination, and providing a Flyway migration to register SQLite as a configurable data source type with default connection parameters. The frontend will dynamically render the datasource configuration form based on this new type, requiring no frontend code changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1b4ba3a-125a-494c-97b5-69e0fa3594d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1b4ba3a-125a-494c-97b5-69e0fa3594d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

